### PR TITLE
Issue 59 60

### DIFF
--- a/lib/kaskara/clang/backend/Dockerfile
+++ b/lib/kaskara/clang/backend/Dockerfile
@@ -19,8 +19,8 @@ RUN cd /tmp \
 
 # install nlohmann/json
 RUN cd /tmp \
- && wget https://github.com/nlohmann/json/archive/v3.1.2.tar.gz \
- && tar -xf v3.1.2.tar.gz \
+ && wget https://github.com/nlohmann/json/archive/v3.11.2.tar.gz \
+ && tar -xf v3.11.2.tar.gz \
  && cd json* \
  && mkdir build \
  && cd build \

--- a/lib/kaskara/clang/backend/Dockerfile
+++ b/lib/kaskara/clang/backend/Dockerfile
@@ -29,6 +29,7 @@ RUN cd /tmp \
  && make install \
  && rm -rf /tmp/*
 
+RUN [ ! -e /opt/llvm11 ] && [ -e /opt/llvm ] && ln -sf /opt/llvm /opt/llvm11
 # build and install
 ADD . /tmp/kaskara
 RUN mkdir /tmp/kaskara/build && \

--- a/lib/kaskara/clang/backend/Dockerfile
+++ b/lib/kaskara/clang/backend/Dockerfile
@@ -19,7 +19,7 @@ RUN cd /tmp \
 
 # install nlohmann/json
 RUN cd /tmp \
- && wget -nv https://github.com/nlohmann/json/archive/v3.1.2.tar.gz \
+ && wget https://github.com/nlohmann/json/archive/v3.1.2.tar.gz \
  && tar -xf v3.1.2.tar.gz \
  && cd json* \
  && mkdir build \


### PR DESCRIPTION
This branch resolves issues #59 and #60, includes the updated version of  `nlohmann::json` from `v3.1.2` to `v3.11.2`.

Anyone consuming this update should ensure that all previous, related docker containers and images are pruned, then rebuilt.